### PR TITLE
Missing part of a line in the config for krb5.conf

### DIFF
--- a/_posts/2021-03-25-ubuntu-active-directory.md
+++ b/_posts/2021-03-25-ubuntu-active-directory.md
@@ -31,7 +31,7 @@ nano /etc/krb5.conf
 This configuration provides some default options. Modify the domain name to match your Active Directory configuration.
 ```
 [libdefaults]
-MYDOMAIN.NET
+default_domain = MYDOMAIN.NET
 rdns = false
 ```
 *Note:* Make sure to enter your domain name in ALL CAPS.


### PR DESCRIPTION
Missing part of a line in the config for krb5.conf

Gist is already correct at the bottom of the page